### PR TITLE
Replacing spaces to tab in Debian rules file

### DIFF
--- a/builds/linux/obs/debian/rules
+++ b/builds/linux/obs/debian/rules
@@ -15,16 +15,16 @@ configure: configure-stamp
 configure-stamp:
 	dh_testdir
 	# Start custom configuration command
-        if [ -f ../complete.zip ] ; then                     \
-             cp ../complete.zip mainApp/extras ;             \
-        else
-             echo "complete.zip not found!" ;                \
-        fi ;
-        if [ -f ../lpub3dldrawunf.zip ] ; then               \
-             cp ../lpub3dldrawunf.zip mainApp/extras ;       \
-        else
-             echo "lpub3dldrawunf.zip not found!" ;          \
-        fi ;
+	if [ -f ../complete.zip ] ; then                     \
+		cp ../complete.zip mainApp/extras ;             \
+	else
+		echo "complete.zip not found!" ;                \
+	fi ;
+	if [ -f ../lpub3dldrawunf.zip ] ; then               \
+		cp ../lpub3dldrawunf.zip mainApp/extras ;       \
+	else
+		echo "lpub3dldrawunf.zip not found!" ;          \
+	fi ;
 override_dh_auto_configure:
 	if [ `uname -m` = "x86_64" ] ; then      \
 		/usr/lib/x86_64-linux-gnu/qt5/bin/qmake -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=deb; \


### PR DESCRIPTION
debian/rules:18: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.