### PR TITLE
Fix lpub3d.spec for 32 bit systems

### DIFF
--- a/builds/linux/obs/lpub3d.spec
+++ b/builds/linux/obs/lpub3d.spec
@@ -163,10 +163,13 @@ fi ;
 export Q_CXXFLAGS="$Q_CXXFLAGS -fPIC"
 %endif
 %endif
+%ifarch x86_64
+export QMAKE_EXTRA_OPT=CONFIG+=rpm
+%endif
 if which qmake-qt5 >/dev/null 2>/dev/null ; then 		            \
-    qmake-qt5 -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=rpm ;\
+    qmake-qt5 -makefile -nocache QMAKE_STRIP=: CONFIG+=release $QMAKE_EXTRA_OPT ;\
 else													\
-    qmake -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=rpm ;    \
+    qmake -makefile -nocache QMAKE_STRIP=: CONFIG+=release $QMAKE_EXTRA_OPT ;    \
 fi ;													\
 make clean
 make %{?_smp_mflags}


### PR DESCRIPTION
rpm file fails on 32 bit systems.

Qt/qmake copies library files to usr/lib32

RPM find these lbraries under usr/lib (see %{_libdir})

If I remove CONFIG+=rpm from qmake arguments 32bit passes, 64bit fails. So we need conditional checking.