### PR TITLE
Fixing rpmlint warnings standard-dir-owned-by-package in lpub3d.spec

### DIFF
--- a/builds/linux/obs/lpub3d.spec
+++ b/builds/linux/obs/lpub3d.spec
@@ -212,13 +212,16 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %{_bindir}/*
 %{_libdir}/*
-%{_datadir}/*
+%{_datadir}/pixmaps/*
+%{_datadir}/mime/packages/*
+%{_datadir}/applications/*
+%attr(644,-,-) %{_datadir}/icons/hicolor/scalable/mimetypes/*
+%{_datadir}/lpub3d
+%doc %{_docdir}/lpub3d
 %{_mandir}/man1/*
 
-%post
-/sbin/ldconfig
-%postun
-/sbin/ldconfig
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %changelog
 * %{changedate} - trevor.dot.sandy.at.gmail.dot.com %{version}


### PR DESCRIPTION
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/mime
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/applications
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/icons
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/man/man1
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/man
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/mime/packages
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/doc
lpub3d.x86_64: W: standard-dir-owned-by-package /usr/share/pixmaps
This package owns a directory that is part of the standard hierarchy, which
can lead to default directory permissions or ownerships being changed to
something non-standard.

lpub3d.x86_64: W: script-without-shebang /usr/share/icons/hicolor/scalable/mimetypes/x-multi-part-ldraw.svg
lpub3d.x86_64: W: script-without-shebang /usr/share/icons/hicolor/scalable/mimetypes/x-ldraw.svg
lpub3d.x86_64: W: script-without-shebang /usr/share/icons/hicolor/scalable/mimetypes/x-multipart-ldraw.svg
This text file has executable bits set or is located in a path dedicated for
executables, but lacks a shebang and cannot thus be executed.  If the file is
meant to be an executable script, add the shebang, otherwise remove the
executable bits or move the file elsewhere.