### PR TITLE
Fix doc path on SUSE distributions

### DIFF
--- a/builds/linux/obs/lpub3d.spec
+++ b/builds/linux/obs/lpub3d.spec
@@ -193,9 +193,9 @@ export Q_CXXFLAGS="$Q_CXXFLAGS -fPIC"
 %endif
 %endif
 if which qmake-qt5 >/dev/null 2>/dev/null ; then 
-	qmake-qt5 -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=rpm 
+	qmake-qt5 -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=rpm DOCS_DIR=%{_docdir}/lpub3d
 else
-	qmake -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=rpm
+	qmake -makefile -nocache QMAKE_STRIP=: CONFIG+=release CONFIG+=rpm DOCS_DIR=%{_docdir}/lpub3d
 fi 
 make clean
 make %{?_smp_mflags}


### PR DESCRIPTION
The RPM macro %{_docdir} points to /usr/share/doc/packages/ on SUSE, on Fedora/RedHat it points to /usr/share/doc

QMake install doc files to /usr/share/doc. QMake does not know the distribution specific directories.

So RPM build fails on SUSE distros:

error: File not found: /home/abuild/rpmbuild/BUILDROOT/lpub3d-2.0.20.690-44.1.i386/usr/share/doc/packages/lpub3d